### PR TITLE
Changed the directory where download the keys

### DIFF
--- a/script/index.lua
+++ b/script/index.lua
@@ -23,7 +23,7 @@ function init()
         motd = Network.requestString("http://matmaf.github.io/encTitleKeys.bin-Updater/motd")
     else
    		Screen.debugPrint(5,5, "encTitleKeysUpdater for freeShop", yellow, TOP_SCREEN)
-    	Screen.debugPrint(30,200, "v1.3", white, TOP_SCREEN)
+    	Screen.debugPrint(30,200, "v1.3.1", white, TOP_SCREEN)
     	Screen.debugPrint(30,215, "by MatMaf", white, TOP_SCREEN)
         Screen.debugPrint(30,20, "Wi-Fi is disabled. Restart and try again.", red, TOP_SCREEN)
         Screen.debugPrint(30,35, "Press B to go back to Homemenu", red, TOP_SCREEN)
@@ -42,20 +42,21 @@ function main()
     Screen.refresh()
     Screen.clear(TOP_SCREEN)
     Screen.debugPrint(5,5, "encTitleKeysUpdater for freeShop", yellow, TOP_SCREEN)
-    Screen.debugPrint(30,200, "v1.3", white, TOP_SCREEN)
+    Screen.debugPrint(30,200, "v1.3.1", white, TOP_SCREEN)
     Screen.debugPrint(30,215, "by MatMaf", white, TOP_SCREEN)
     Screen.debugPrint(5,5, motd, white, BOTTOM_SCREEN)
     Screen.flip()
 
     if Network.isWifiEnabled() then
         Screen.debugPrint(30,20, "Updating...", green, TOP_SCREEN)
-        System.createDirectory("/freeShop")
+        System.createDirectory("/3ds/data/freeShop")
+        System.createDirectory("/3ds/data/freeShop/keys")
         Network.downloadFile("http://3ds.titlekeys.com/downloadenc", "/encTitleKeysTemp.bin")
         if System.doesFileExist("/encTitleKeysTemp.bin") then
-        	if System.doesFileExist("/freeShop/encTitleKeys.bin") then
-        		System.deleteFile("/freeShop/encTitleKeys.bin")
+        	if System.doesFileExist("/3ds/data/freeShop/keys/encTitleKeys.bin") then
+        		System.deleteFile("/3ds/data/freeShop/keys/encTitleKeys.bin")
         	end
-        	System.renameFile("/encTitleKeysTemp.bin", "/freeShop/encTitleKeys.bin")
+        	System.renameFile("/encTitleKeysTemp.bin", "/3ds/data/freeShop/keys/encTitleKeys.bin")
         	Screen.waitVblankStart()
             Screen.flip()
             System.launchCIA(0x0f12ee00,SDMC)


### PR DESCRIPTION
freeShop 2.0 changed the directory where he read the keys.
This is a quick painless fix.

Builded successfully and it works correctly.
Have to manually delete the old 'freeShop' Dir.